### PR TITLE
Allow explicit band selection in both API and commandline tool

### DIFF
--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -10,7 +10,8 @@ from sentinelhub import download_safe_format, get_safe_format, download_data
 @click.option('-t', '--threaded', is_flag=True, default=False, help='Use threaded download')
 @click.option('-i', '--info', is_flag=True, default=False, help='Return safe format structure')
 @click.option('-e', '--entire', is_flag=True, default=False, help='Get entire product of specified tile')
-def aws(product, tile, folder, redownload, threaded, info, entire):
+@click.option('-b', '--bands', default=None, help='Comma separated list (no spaces) of bands to retrieve')
+def aws(product, tile, folder, redownload, threaded, info, entire, bands):
     """Download Sentinel-2 data from Sentinel-2 on AWS to ESA SAFE format.
 
     \b
@@ -18,9 +19,11 @@ def aws(product, tile, folder, redownload, threaded, info, entire):
       sentinelhub.aws --product S2A_MSIL1C_20170414T003551_N0204_R016_T54HVH_20170414T003551
       sentinelhub.aws --product S2A_MSIL1C_20170414T003551_N0204_R016_T54HVH_20170414T003551 -i
       sentinelhub.aws --product S2A_MSIL1C_20170414T003551_N0204_R016_T54HVH_20170414T003551 -f /home/ESA_Products
+      sentinelhub.aws --product S2A_MSIL1C_20170414T003551_N0204_R016_T54HVH_20170414T003551 --bands B08,B11
       sentinelhub.aws --tile T54HVH 2017-04-14
       sentinelhub.aws --tile T54HVH 2017-04-14 -e
     """
+    bandz = None if bands is None else bands.split(',')
     if info:
         if product is None:
             click.echo(get_safe_format(tile=tile, entire_product=entire))
@@ -28,9 +31,9 @@ def aws(product, tile, folder, redownload, threaded, info, entire):
             click.echo(get_safe_format(product_id=product))
     else:
         if product is None:
-            download_safe_format(tile=tile, folder=folder, redownload=redownload, threaded_download=threaded, entire_product=entire)
+            download_safe_format(tile=tile, folder=folder, redownload=redownload, threaded_download=threaded, entire_product=entire, bands=bandz)
         else:
-            download_safe_format(product_id=product, folder=folder, redownload=redownload, threaded_download=threaded)
+            download_safe_format(product_id=product, folder=folder, redownload=redownload, threaded_download=threaded, bands=bandz)
 
 
 @click.command()


### PR DESCRIPTION
This is a relatively simple change that allows the user to specify which bands to download. For users who need only a subset of the available bands, this reduces requirements for download time, network bandwidth, and storage space.

I apologize for the pull request with no prior contact about this feature. I implemented it for my own use and afterward realized it might be useful to others.