### PR TITLE
Fix downloading tiles with single-digit UTM zone

### DIFF
--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -345,7 +345,7 @@ def tile_id_to_namedate(tile_id):
     return name, date
 
 def namedate_to_url(name, date, index=0):
-    return '/'.join([MAIN_URL, 'tiles', name[:2], name[2], name[3:5], date.replace(DATE_SEPARATOR, '/'), str(index)])
+    return '/'.join([MAIN_URL, 'tiles', name[:-3], name[-3], name[-2:], date.replace(DATE_SEPARATOR, '/'), str(index)])
 
 # "tiles/13/P/HS/2016/1/3/0"
 def url_to_namedate(url):


### PR DESCRIPTION
Should fix #8 
I'm assuming that a tile is defined by 1 or 2 digits followed by 3 letters.